### PR TITLE
Fix: preserve jwt details when switching auth type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/google-sdk",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Common Google features for grafana",
   "main": "dist/index.js",
   "scripts": {

--- a/src/ConnectionConfig.test.tsx
+++ b/src/ConnectionConfig.test.tsx
@@ -153,13 +153,14 @@ describe('ConnectionConfig', () => {
     expect(screen.queryByTestId(TEST_IDS.dropZone)).not.toBeInTheDocument();
   });
 
-  it('resets service account credentials when changing auth type', () => {
+  it('preserves service account credentials when changing auth type', () => {
     const onOptionsChangeSpy = jest.fn();
 
     const { getByLabelText } = render(
       <ConnectionConfig
         options={
           ({
+            secureJsonData: {},
             jsonData: {
               authenticationType: GoogleAuthType.JWT,
               clientEmail: 'test@grafana.com',
@@ -176,7 +177,12 @@ describe('ConnectionConfig', () => {
     fireEvent.click(gceAuthButton);
 
     expect(onOptionsChangeSpy).toHaveBeenCalledWith({
-      jsonData: { authenticationType: GoogleAuthType.GCE },
+      jsonData: {
+        authenticationType: GoogleAuthType.GCE,
+        clientEmail: 'test@grafana.com',
+        defaultProject: 'test-project',
+        tokenUri: 'https://accounts.google.com/o/oauth2/token',
+      },
       secureJsonData: {},
     });
   });

--- a/src/ConnectionConfig.test.tsx
+++ b/src/ConnectionConfig.test.tsx
@@ -19,6 +19,17 @@ const TOKEN_MOCK = `{
 }
 `;
 
+const makeJsonData: (
+  authenticationType?: GoogleAuthType
+) => DataSourceSettings<DataSourceOptions, DataSourceSecureJsonData>['jsonData'] = (
+  authenticationType = GoogleAuthType.JWT
+) => ({
+  authenticationType,
+  clientEmail: 'test@grafana.com',
+  tokenUri: 'https://accounts.google.com/o/oauth2/token',
+  defaultProject: 'test-project',
+});
+
 describe('ConnectionConfig', () => {
   it('renders help box', () => {
     render(
@@ -96,15 +107,12 @@ describe('ConnectionConfig', () => {
   });
 
   it('renders drop zone on JWT token reset', () => {
+    const jsonData = makeJsonData();
     const { getByTestId } = render(
       <WrapInState
         defaultOptions={
           ({
-            jsonData: {
-              clientEmail: 'test@grafana.com',
-              tokenUri: 'https://accounts.google.com/o/oauth2/token',
-              defaultProject: 'test-project',
-            },
+            jsonData,
             secureJsonFields: {
               privateKey: true,
             },
@@ -130,15 +138,12 @@ describe('ConnectionConfig', () => {
   });
 
   it('renders JWT form when data is provided', () => {
+    const jsonData = makeJsonData();
     render(
       <ConnectionConfig
         options={
           ({
-            jsonData: {
-              clientEmail: 'test@grafana.com',
-              tokenUri: 'https://accounts.google.com/o/oauth2/token',
-              defaultProject: 'test-project',
-            },
+            jsonData,
             secureJsonFields: {
               privateKey: true,
             },
@@ -155,18 +160,15 @@ describe('ConnectionConfig', () => {
 
   it('preserves service account credentials when changing auth type', () => {
     const onOptionsChangeSpy = jest.fn();
+    const jsonData = makeJsonData();
+    const expectedJsonData = makeJsonData(GoogleAuthType.GCE);
 
     const { getByLabelText } = render(
       <ConnectionConfig
         options={
           ({
             secureJsonData: {},
-            jsonData: {
-              authenticationType: GoogleAuthType.JWT,
-              clientEmail: 'test@grafana.com',
-              tokenUri: 'https://accounts.google.com/o/oauth2/token',
-              defaultProject: 'test-project',
-            },
+            jsonData,
           } as unknown) as DataSourceSettings<DataSourceOptions, DataSourceSecureJsonData>
         }
         onOptionsChange={onOptionsChangeSpy}
@@ -177,12 +179,7 @@ describe('ConnectionConfig', () => {
     fireEvent.click(gceAuthButton);
 
     expect(onOptionsChangeSpy).toHaveBeenCalledWith({
-      jsonData: {
-        authenticationType: GoogleAuthType.GCE,
-        clientEmail: 'test@grafana.com',
-        defaultProject: 'test-project',
-        tokenUri: 'https://accounts.google.com/o/oauth2/token',
-      },
+      jsonData: expectedJsonData,
       secureJsonData: {},
     });
   });

--- a/src/ConnectionConfig.tsx
+++ b/src/ConnectionConfig.tsx
@@ -21,7 +21,10 @@ export const ConnectionConfig: React.FC<ConfigEditorProps> = (props: ConfigEdito
   const isJWT = jsonData.authenticationType === GoogleAuthType.JWT || jsonData.authenticationType === undefined;
 
   const onAuthTypeChange = (authenticationType: GoogleAuthType) => {
-    onResetApiKey({ authenticationType });
+    onOptionsChange({
+      ...options,
+      jsonData: { ...options.jsonData, authenticationType },
+    });
   };
 
   const hasJWTConfigured = Boolean(


### PR DESCRIPTION
https://github.com/grafana/grafana-google-sdk-react/issues/3

Preserves existing JWT details when switching between auth types.