### PR TITLE
add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# More details are here: https://help.github.com/articles/about-codeowners/
+
+# The '*' pattern is global owners.
+
+# Order is important. The last matching pattern has the most precedence.
+# The folders are ordered as follows:
+
+# In each subsection folders are ordered first by depth, then alphabetically.
+# This should make it easy to add new rules without breaking existing ones.
+
+* @grafana/cloud-datasources


### PR DESCRIPTION
Add cloud datasources team as codeowners to enable auto tagging team members as reviewers.

Our teams needs write permissions for this repo. I think this will also enable our team to be selectable in the `Reviewers` list for PRs to this repo. @vickyyyyyyy are you able to add write permissions for our team to this repo?