### PR TITLE
fix: prevent double publish from happening

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -56,6 +56,6 @@ jobs:
 
       - name: Publish package to Github Packages
         if: steps.version_check.outputs.changed == 'true'
-        run: npm publish
+        run: npm publish --access public --scope grafana
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGE_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "bundle": "rollup -c rollup.config.ts",
     "clean": "rimraf ./dist ./compiled",
     "typecheck": "tsc --noEmit",
-    "publish": "npm publish  --access=public --scope=grafana",
     "test": "jest --notify --watch",
     "test-ci": "grafana-toolkit plugin:test"
   },


### PR DESCRIPTION
Having a npm script named `publish` defined means when `npm publish` is invoked it's also [invokes the script](https://stackoverflow.com/a/72176325/2344737) after the `publish` run 🙄 This fixes this [double run](https://github.com/grafana/grafana-google-sdk-react/actions/runs/3312785197/jobs/5469887850) by removing the npm script.