### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,4 @@
 # In each subsection folders are ordered first by depth, then alphabetically.
 # This should make it easy to add new rules without breaking existing ones.
 
-* @grafana/cloud-provider-plugins
+* @grafana/partner-plugins


### PR DESCRIPTION
We have renamed the `Cloud Provider Plugins` squad to `Partner Plugins` (https://github.com/orgs/grafana/teams/partner-plugins) and would like the changes to be reflected in the CODEOWNERS file.