### PR TITLE
Chore: Move grafana deps to peerDeps

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -45,17 +45,3 @@ jobs:
         run: npm publish --access public --scope grafana
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Setup .npmrc file for GitHub Packages
-        if: steps.version_check.outputs.changed == 'true'
-        uses: actions/setup-node@v2
-        with:
-          node-version: '16'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@grafana'
-
-      - name: Publish package to Github Packages
-        if: steps.version_check.outputs.changed == 'true'
-        run: npm publish --access public --scope grafana
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGE_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.1.1
+
+- Move grafana dependencies to peerDependencies
+- Remove GitHub package release
+
 ## v0.1.0
 
 - Export AuthConfig.tsx that can be reused without the infobox

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/google-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Common Google features for grafana",
   "main": "index.js",
   "types": "dist/index.d.ts",
@@ -20,19 +20,23 @@
   "repository": "github:grafana/grafana-google-sdk-react",
   "author": "Grafana Labs <team@grafana.com> (https://grafana.com)",
   "license": "Apache-2.0",
-  "dependencies": {
+  "peerDependencies": {
     "@grafana/data": "9.4.1",
     "@grafana/ui": "9.4.1",
     "react": "17.0.2",
     "react-dom": "17.0.2"
   },
   "devDependencies": {
+    "@grafana/data": "9.4.1",
     "@grafana/toolkit": "9.4.1",
+    "@grafana/ui": "9.4.1",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-node-resolve": "^13.1.1",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.1.2",
     "@types/lodash": "^4.14.178",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
     "rimraf": "^3.0.2",
     "rollup": "^2.61.1",
     "rollup-plugin-terser": "^7.0.2",


### PR DESCRIPTION
I was wrongly added the grafana dependencies to dependencies in package.json. This made in the grafana main repo to pull grafana 9.4.1 as well, that is not desired.

Also removed the GitHub package release step as it failed in main and IMO not needed. 