### PR TITLE
Add service account impersonation feature to AuthConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.3.0
+
+- Add service account impersonation support
+
 ## v0.2.0
 
 - Update package bundling to emit ESM and CJS modules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/google-sdk",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Common Google features for grafana",
   "type": "module",
   "main": "dist/cjs/index.cjs",

--- a/src/components/AuthConfig.tsx
+++ b/src/components/AuthConfig.tsx
@@ -1,9 +1,16 @@
 import {
   type DataSourceSettings,
   onUpdateDatasourceJsonDataOption,
+  onUpdateDatasourceJsonDataOptionChecked,
   type SelectableValue,
 } from "@grafana/data";
-import { Field, FieldSet, Input, RadioButtonGroup } from "@grafana/ui";
+import {
+  Field,
+  FieldSet,
+  Input,
+  RadioButtonGroup,
+  Switch
+} from "@grafana/ui";
 import React, { useState } from "react";
 import {
   type DataSourceOptions,
@@ -153,6 +160,51 @@ export function AuthConfig(props: AuthConfigProps) {
           />
         </Field>
       )}
+
+      <FieldSet label="Service account impersonation">
+        <Field
+          label="Enable"
+          htmlFor="usingImpersonation"
+          description={
+            <span>
+              Read more about service account impersonation{" "}
+              <a
+                href="https://cloud.google.com/iam/docs/service-account-impersonation"
+                rel="noreferrer"
+                className="external-link"
+                target="_blank"
+              >
+                here
+              </a>
+            </span>
+          }
+        >
+          <Switch
+            value={options.jsonData.usingImpersonation || false}
+            onChange={onUpdateDatasourceJsonDataOptionChecked(
+              props,
+              "usingImpersonation"
+            )}
+            id="usingImpersonation"
+          />
+        </Field>
+        {options.jsonData.usingImpersonation && (
+          <Field
+            label="Service account to impersonate"
+            htmlFor="serviceAccountToImpersonate"
+          >
+            <Input
+              id="serviceAccountToImpersonate"
+              width={60}
+              value={options.jsonData.serviceAccountToImpersonate || ""}
+              onChange={onUpdateDatasourceJsonDataOption(
+                props,
+                "serviceAccountToImpersonate"
+              )}
+            />
+          </Field>
+        )}
+      </FieldSet>
     </>
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,8 @@ export interface DataSourceOptions extends DataSourceJsonData {
   clientEmail?: string;
   defaultProject?: string;
   privateKeyPath?: string;
+  serviceAccountToImpersonate?: string;
+  usingImpersonation?: boolean;
 }
 
 export interface DataSourceSecureJsonData {


### PR DESCRIPTION
Introduce support for service account impersonation in AuthConfig, allowing users to enable impersonation and specify a service account.
<img width="694" alt="Screenshot 2025-06-16 at 13 47 24" src="https://github.com/user-attachments/assets/05987db9-dece-4e8e-ad76-22566bd242c3" />

This is needed for https://github.com/grafana/google-bigquery-datasource/issues/310 and https://github.com/grafana/google-bigquery-datasource/pull/336
