### PR TITLE
Fix: Do not mutate options object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.3.1
+
+- Fix: do not mutate the options object
+
 ## v0.3.0
 
 - Add service account impersonation support

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-// @ts-check
+import path from "path";
 
 /*
  * This utility function is useful in combination with jest `transformIgnorePatterns` config
@@ -43,6 +43,12 @@ const config = {
   setupFilesAfterEnv: ["<rootDir>/jest-setup.js"],
   moduleNameMapper: {
     "\\.(css|scss|sass)$": "identity-obj-proxy",
+    "react-inlinesvg": path.resolve(
+      path.dirname(""),
+      "jest",
+      "mocks",
+      "react-inlinesvg.tsx"
+    ),
   },
   testEnvironment: "jest-environment-jsdom",
   // Jest will throw `Cannot use import statement outside module` if it tries to load an

--- a/jest/mocks/react-inlinesvg.tsx
+++ b/jest/mocks/react-inlinesvg.tsx
@@ -1,0 +1,31 @@
+// Due to the grafana/ui Icon component making fetch requests to
+// `/public/img/icon/<icon_name>.svg` we need to mock react-inlinesvg to prevent
+// the failed fetch requests from displaying errors in console.
+
+import React from "react";
+
+type Callback = (...args: any[]) => void;
+
+export interface StorageItem {
+  content: string;
+  queue: Callback[];
+  status: string;
+}
+
+export const cacheStore: { [key: string]: StorageItem } = Object.create(null);
+
+const SVG_FILE_NAME_REGEX = /(.+)\/(.+)\.svg$/;
+
+const InlineSVG = ({ src }: { src: string }) => {
+  // testId will be the file name without extension (e.g. `public/img/icons/angle-double-down.svg` -> `angle-double-down`)
+  const testId = src.replace(SVG_FILE_NAME_REGEX, "$2");
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      data-testid={testId}
+      viewBox="0 0 24 24"
+    />
+  );
+};
+
+export default InlineSVG;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/google-sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Common Google features for grafana",
   "type": "module",
   "main": "dist/cjs/index.cjs",

--- a/src/ConnectionConfig.test.tsx
+++ b/src/ConnectionConfig.test.tsx
@@ -315,7 +315,7 @@ describe("ConnectionConfig", () => {
 
   it("makes sure JWT is selected by default", () => {
     const onOptionsChangeSpy = jest.fn();
-    const jsonData = deepFreeze({});
+    const jsonData = Object.freeze({});
 
     render(
       <ConnectionConfig
@@ -357,20 +357,3 @@ const WrapInState = ({ defaultOptions, children }: WrapInStateProps) => {
   const [options, setOptions] = useState(defaultOptions);
   return children({ options, setOptions });
 };
-
-function deepFreeze(obj: any): Readonly<any> {
-  // Retrieve the property names defined on obj
-  const propNames = Object.getOwnPropertyNames(obj);
-
-  // Freeze properties before freezing self
-  for (const name of propNames) {
-    const value = obj[name];
-
-    // If value is an object, freeze it recursively
-    if (value && typeof value === "object") {
-      deepFreeze(value);
-    }
-  }
-
-  return Object.freeze(obj);
-}

--- a/src/ConnectionConfig.tsx
+++ b/src/ConnectionConfig.tsx
@@ -9,6 +9,7 @@ import {
   type DataSourceSecureJsonData,
   GoogleAuthType,
 } from "./types";
+import { getOptionsWithDefaults } from "./utils";
 
 export type ConfigEditorProps = DataSourcePluginOptionsEditorProps<
   DataSourceOptions,
@@ -18,21 +19,19 @@ export type ConfigEditorProps = DataSourcePluginOptionsEditorProps<
 export const ConnectionConfig: React.FC<ConfigEditorProps> = (
   props: ConfigEditorProps
 ) => {
-  const {
-    options: { jsonData },
-  } = props;
-
-  if (!jsonData.authenticationType) {
-    jsonData.authenticationType = GoogleAuthType.JWT;
-  }
+  const optionsWithDefault = getOptionsWithDefaults(props.options);
 
   const isJWT =
-    jsonData.authenticationType === GoogleAuthType.JWT ||
-    jsonData.authenticationType === undefined;
+    optionsWithDefault.jsonData.authenticationType === GoogleAuthType.JWT ||
+    optionsWithDefault.jsonData.authenticationType === undefined;
 
   return (
     <>
-      <AuthConfig authOptions={GOOGLE_AUTH_TYPE_OPTIONS} {...props} />
+      <AuthConfig
+        authOptions={GOOGLE_AUTH_TYPE_OPTIONS}
+        onOptionsChange={props.onOptionsChange}
+        options={optionsWithDefault}
+      />
       <div
         className="grafana-info-box"
         style={{ marginTop: "16px" }}

--- a/src/components/AuthConfig.tsx
+++ b/src/components/AuthConfig.tsx
@@ -4,19 +4,14 @@ import {
   onUpdateDatasourceJsonDataOptionChecked,
   type SelectableValue,
 } from "@grafana/data";
-import {
-  Field,
-  FieldSet,
-  Input,
-  RadioButtonGroup,
-  Switch
-} from "@grafana/ui";
+import { Field, FieldSet, Input, RadioButtonGroup, Switch } from "@grafana/ui";
 import React, { useState } from "react";
 import {
   type DataSourceOptions,
   type DataSourceSecureJsonData,
   GoogleAuthType,
 } from "../types";
+import { getOptionsWithDefaults } from "../utils";
 import { JWTConfigEditor } from "./JWTConfigEditor";
 import { JWTForm } from "./JWTForm";
 
@@ -30,7 +25,8 @@ export interface AuthConfigProps {
 
 export function AuthConfig(props: AuthConfigProps) {
   const { options, onOptionsChange, authOptions } = props;
-  const { jsonData, secureJsonFields, secureJsonData } = options;
+  const { jsonData, secureJsonFields, secureJsonData } =
+    getOptionsWithDefaults(options);
   const getJTWConfig = (): boolean =>
     Boolean(
       jsonData.clientEmail &&
@@ -39,10 +35,6 @@ export function AuthConfig(props: AuthConfigProps) {
         ((secureJsonFields && secureJsonFields.privateKey) ||
           jsonData.privateKeyPath)
     );
-
-  if (!jsonData.authenticationType) {
-    jsonData.authenticationType = GoogleAuthType.JWT;
-  }
 
   const [jwtAuth, setJWTAuth] = useState<boolean>(
     isJWTAuth(jsonData.authenticationType)

--- a/src/tests/setupTests.ts
+++ b/src/tests/setupTests.ts
@@ -1,3 +1,0 @@
-// enables assertions such as toBeInTheDocument to be used in our tests
-import '@testing-library/jest-dom';
-import '@testing-library/jest-dom/extend-expect';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,26 @@
+import type { DataSourceSettings } from "@grafana/data";
+import {
+  type DataSourceOptions,
+  type DataSourceSecureJsonData,
+  GoogleAuthType,
+} from "./types";
+
+/**
+ * Ensures that the `options` object contains a default `authenticationType` in its `jsonData` property.
+ *
+ * If `options.jsonData.authenticationType` is not set, this function returns a new options object
+ * with `authenticationType` set to `GoogleAuthType.JWT`. Otherwise, it returns the original options object.
+ *
+ */
+export const getOptionsWithDefaults = (
+  options: DataSourceSettings<DataSourceOptions, DataSourceSecureJsonData>
+) => {
+  if (!options.jsonData.authenticationType) {
+    return {
+      ...options,
+      jsonData: { ...options.jsonData, authenticationType: GoogleAuthType.JWT },
+    };
+  }
+
+  return options;
+};

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,5 +5,12 @@
     "emitDeclarationOnly": true,
     "noEmit": false
   },
-  "exclude": ["**/*.test.ts*", "test", "dist", "compiled", "node_modules"]
+  "exclude": [
+    "**/*.test.ts*",
+    "test",
+    "dist",
+    "compiled",
+    "node_modules",
+    "./jest-setup.js"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "target": "es2022",
     "verbatimModuleSyntax": true
   },
-  "include": ["src"]
+  "include": ["src", "./jest-setup.js"]
 }


### PR DESCRIPTION
- Update package version to 0.3.1
- Introduce `getOptionsWithDefaults` utility to ensure default authentication type
- Refactor `ConnectionConfig` and `AuthConfig` to utilize new utility
- Add mock for `react-inlinesvg` to prevent fetch errors in tests
- Remove unused setupTests file

Needs for https://github.com/grafana/google-bigquery-datasource/pull/344

How to test:

- Run `yarn build` in this repository
- Check out https://github.com/grafana/google-bigquery-datasource/pull/344
- Run `yarn link {YOUR_PATH}/grafana-google-sdk-react`
- Run `yarn build` in the BigQuery repository as well
- Visit the config page 