### PR TITLE
Add `showServiceAccountImpersonationConfig` prop to `AuthConfig` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.3.3
+
+- Add `showServiceAccountImpersonationConfig` prop to `AuthConfig` component
+
 ## v0.3.2
 
 - Fix package.jon repository URL

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/google-sdk",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Common Google features for grafana",
   "type": "module",
   "main": "dist/cjs/index.cjs",

--- a/src/components/AuthConfig.tsx
+++ b/src/components/AuthConfig.tsx
@@ -21,10 +21,16 @@ export interface AuthConfigProps {
   onOptionsChange: (
     options: DataSourceSettings<DataSourceOptions, DataSourceSecureJsonData>
   ) => void;
+  showServiceAccountImpersonationConfig?: boolean;
 }
 
 export function AuthConfig(props: AuthConfigProps) {
-  const { options, onOptionsChange, authOptions } = props;
+  const {
+    options,
+    onOptionsChange,
+    authOptions,
+    showServiceAccountImpersonationConfig,
+  } = props;
   const { jsonData, secureJsonFields, secureJsonData } =
     getOptionsWithDefaults(options);
   const getJTWConfig = (): boolean =>
@@ -152,51 +158,52 @@ export function AuthConfig(props: AuthConfigProps) {
           />
         </Field>
       )}
-
-      <FieldSet label="Service account impersonation">
-        <Field
-          label="Enable"
-          htmlFor="usingImpersonation"
-          description={
-            <span>
-              Read more about service account impersonation{" "}
-              <a
-                href="https://cloud.google.com/iam/docs/service-account-impersonation"
-                rel="noreferrer"
-                className="external-link"
-                target="_blank"
-              >
-                here
-              </a>
-            </span>
-          }
-        >
-          <Switch
-            value={options.jsonData.usingImpersonation || false}
-            onChange={onUpdateDatasourceJsonDataOptionChecked(
-              props,
-              "usingImpersonation"
-            )}
-            id="usingImpersonation"
-          />
-        </Field>
-        {options.jsonData.usingImpersonation && (
+      {showServiceAccountImpersonationConfig && (
+        <FieldSet label="Service account impersonation">
           <Field
-            label="Service account to impersonate"
-            htmlFor="serviceAccountToImpersonate"
+            label="Enable"
+            htmlFor="usingImpersonation"
+            description={
+              <span>
+                Read more about service account impersonation{" "}
+                <a
+                  href="https://cloud.google.com/iam/docs/service-account-impersonation"
+                  rel="noreferrer"
+                  className="external-link"
+                  target="_blank"
+                >
+                  here
+                </a>
+              </span>
+            }
           >
-            <Input
-              id="serviceAccountToImpersonate"
-              width={60}
-              value={options.jsonData.serviceAccountToImpersonate || ""}
-              onChange={onUpdateDatasourceJsonDataOption(
+            <Switch
+              value={options.jsonData.usingImpersonation || false}
+              onChange={onUpdateDatasourceJsonDataOptionChecked(
                 props,
-                "serviceAccountToImpersonate"
+                "usingImpersonation"
               )}
+              id="usingImpersonation"
             />
           </Field>
-        )}
-      </FieldSet>
+          {options.jsonData.usingImpersonation && (
+            <Field
+              label="Service account to impersonate"
+              htmlFor="serviceAccountToImpersonate"
+            >
+              <Input
+                id="serviceAccountToImpersonate"
+                width={60}
+                value={options.jsonData.serviceAccountToImpersonate || ""}
+                onChange={onUpdateDatasourceJsonDataOption(
+                  props,
+                  "serviceAccountToImpersonate"
+                )}
+              />
+            </Field>
+          )}
+        </FieldSet>
+      )}
     </>
   );
 }


### PR DESCRIPTION
We don't want to show the Service Account Impersonation config if it is not implemented or if the authtype not supports it like in Google Sheets API key.