### PR TITLE
Release version 0.3.4 and enable service account impersonation by default in `ConnectionConfig` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.3.4
+
+- Enable service account impersonation by default in `ConnectionConfig` component
+
 ## v0.3.3
 
 - Add `showServiceAccountImpersonationConfig` prop to `AuthConfig` component

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/google-sdk",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Common Google features for grafana",
   "type": "module",
   "main": "dist/cjs/index.cjs",

--- a/src/ConnectionConfig.tsx
+++ b/src/ConnectionConfig.tsx
@@ -30,6 +30,7 @@ export const ConnectionConfig: React.FC<ConfigEditorProps> = (
       <AuthConfig
         authOptions={GOOGLE_AUTH_TYPE_OPTIONS}
         onOptionsChange={props.onOptionsChange}
+        showServiceAccountImpersonationConfig={true}
         options={optionsWithDefault}
       />
       <div


### PR DESCRIPTION
This is used in cloud monitoring data source.