### PR TITLE
Release version 0.3.5 and fix `getOptionsWithDefaults` to call `onOptionsChange` to persist the default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.3.5
+
+- Export `getOptionsWithDefaults` function
+
 ## v0.3.4
 
 - Enable service account impersonation by default in `ConnectionConfig` component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## v0.3.5
 
-- Export `getOptionsWithDefaults` function
+- Fix `getOptionsWithDefaults` function to call `onOptionsChange` to persist the default value
 
 ## v0.3.4
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/google-sdk",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Common Google features for grafana",
   "type": "module",
   "main": "dist/cjs/index.cjs",

--- a/src/ConnectionConfig.tsx
+++ b/src/ConnectionConfig.tsx
@@ -19,7 +19,10 @@ export type ConfigEditorProps = DataSourcePluginOptionsEditorProps<
 export const ConnectionConfig: React.FC<ConfigEditorProps> = (
   props: ConfigEditorProps
 ) => {
-  const optionsWithDefault = getOptionsWithDefaults(props.options);
+  const optionsWithDefault = getOptionsWithDefaults(
+    props.options,
+    props.onOptionsChange
+  );
 
   const isJWT =
     optionsWithDefault.jsonData.authenticationType === GoogleAuthType.JWT ||

--- a/src/components/AuthConfig.tsx
+++ b/src/components/AuthConfig.tsx
@@ -32,7 +32,7 @@ export function AuthConfig(props: AuthConfigProps) {
     showServiceAccountImpersonationConfig,
   } = props;
   const { jsonData, secureJsonFields, secureJsonData } =
-    getOptionsWithDefaults(options);
+    getOptionsWithDefaults(options, onOptionsChange);
   const getJTWConfig = (): boolean =>
     Boolean(
       jsonData.clientEmail &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 export * from "./components";
 export { ConnectionConfig } from "./ConnectionConfig";
-export { getOptionsWithDefaults } from "./utils";
 export * from "./constants";
 export * from "./types";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./components";
 export { ConnectionConfig } from "./ConnectionConfig";
+export { getOptionsWithDefaults } from "./utils";
 export * from "./constants";
 export * from "./types";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,9 +12,10 @@ import {
  * with `authenticationType` set to `GoogleAuthType.JWT`. Otherwise, it returns the original options object.
  *
  */
-export const getOptionsWithDefaults = (
-  options: DataSourceSettings<DataSourceOptions, DataSourceSecureJsonData>
-) => {
+export function getOptionsWithDefaults<
+  TJsonData extends DataSourceOptions,
+  TSecureJsonData extends DataSourceSecureJsonData
+>(options: DataSourceSettings<TJsonData, TSecureJsonData>) {
   if (!options.jsonData.authenticationType) {
     return {
       ...options,
@@ -23,4 +24,4 @@ export const getOptionsWithDefaults = (
   }
 
   return options;
-};
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,16 +12,20 @@ import {
  * with `authenticationType` set to `GoogleAuthType.JWT`. Otherwise, it returns the original options object.
  *
  */
-export function getOptionsWithDefaults<
-  TJsonData extends DataSourceOptions,
-  TSecureJsonData extends DataSourceSecureJsonData
->(options: DataSourceSettings<TJsonData, TSecureJsonData>) {
+export const getOptionsWithDefaults = (
+  options: DataSourceSettings<DataSourceOptions, DataSourceSecureJsonData>,
+  onOptionsChange: (
+    options: DataSourceSettings<DataSourceOptions, DataSourceSecureJsonData>
+  ) => void
+) => {
   if (!options.jsonData.authenticationType) {
-    return {
+    const newOptions = {
       ...options,
       jsonData: { ...options.jsonData, authenticationType: GoogleAuthType.JWT },
     };
+    onOptionsChange(newOptions);
+    return newOptions;
   }
 
   return options;
-}
+};


### PR DESCRIPTION
Although `getOptionsWithDefaults` it sets the default value for authenticationtype it is not persisted so we need to call onOptionsChange.