### PR TITLE
Release version 0.4.1 to fix publish workflow with Trusted Publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,7 +1,7 @@
 name: publish-npm
 permissions:
   contents: read
-  id-token: write
+  id-token: write # needed for Trusted Publishing
 
 on:
   push:
@@ -37,9 +37,10 @@ jobs:
         if: steps.version_check.outputs.changed == 'true'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version-file: ".nvmrc"
-          cache: "yarn"
-          registry-url: "https://registry.npmjs.org"
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+          scope: '@grafana'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         if: steps.version_check.outputs.changed == 'true'
@@ -49,16 +50,6 @@ jobs:
         if: steps.version_check.outputs.changed == 'true'
         run: yarn build
 
-      - name: Get vault secrets
-        if: steps.version_check.outputs.changed == 'true'
-        id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main # zizmor: ignore[unpinned-uses]
-        with:
-          repo_secrets: |
-            NPM_TOKEN=npm-publish:token
-
       - name: Publish package to NPM
         if: steps.version_check.outputs.changed == 'true'
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.4.1
+
+- Fix publish workflow to use Trusted Publishing
+
 ## v0.4.0
 
 - Update dev dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/google-sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Common Google features for grafana",
   "type": "module",
   "main": "dist/cjs/index.cjs",


### PR DESCRIPTION
This is based on https://github.com/grafana/lezer-traceql/pull/38