### PR TITLE
chore(security): Harden package manager configuration against supply-chain attacks

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+ignore-scripts=true
+allow-git=none
+min-release-age=3
+registry=https://registry.npmjs.org/
+save-exact=true
+engine-strict=true

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,15 @@
-nodeLinker: node-modules
+approvedGitRepositories: []  # Yarn ≥ 4.14.0: must be set explicitly; absence causes Yarn to write ["**"] on installs
 
-yarnPath: .yarn/releases/yarn-4.16.0.cjs
-
+checksumBehavior: throw
+defaultSemverRangePrefix: ""
+enableHardenedMode: true
+enableImmutableInstalls: true
 enableScripts: false
+nmHoistingLimits: workspaces
+nodeLinker: node-modules
+npmMinimalAgeGate: 4320  # 3 days in minutes
+npmPreapprovedPackages:
+  - "@grafana/*"
+npmRegistryServer: "https://registry.npmjs.org/"
+unsafeHttpWhitelist: []
+yarnPath: .yarn/releases/yarn-4.16.0.cjs   # keep in sync with package.json "packageManager"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
   },
   "author": "Grafana Labs <team@grafana.com> (https://grafana.com)",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "peerDependencies": {
     "@grafana/data": ">=11.6.0",
     "@grafana/ui": ">=11.6.0",


### PR DESCRIPTION
## Summary

Add comprehensive supply-chain hardening per Grafana security policy to protect against malicious dependencies, compromised packages, and other npm/Yarn-based attacks.

**Critical fix:** Yarn ≥ 4.14.0 requires explicit `approvedGitRepositories: []` or it auto-writes `["**"]` (wildcard) on installs, allowing any git repository as a dependency. This repo uses Yarn 4.16.0 and was vulnerable.

## Changes

### `.yarnrc.yml` - Added 9 hardening keys

- ✅ `approvedGitRepositories: []` - **CRITICAL**: Blocks git-based dependencies (prevents Yarn from auto-writing `["**"]`)
- ✅ `checksumBehavior: throw` - Enforces package integrity validation
- ✅ `defaultSemverRangePrefix: ""` - Requires exact versions (no `^` or `~`)
- ✅ `enableHardenedMode: true` - Activates Yarn's security features
- ✅ `enableImmutableInstalls: true` - Prevents lockfile modifications in CI
- ✅ `npmMinimalAgeGate: 4320` - **3-day minimum release age** for external packages
- ✅ `npmPreapprovedPackages: ["@grafana/*"]` - Allows Grafana packages to bypass age gate
- ✅ `npmRegistryServer: "https://registry.npmjs.org/"` - Locks to official npm registry
- ✅ `unsafeHttpWhitelist: []` - Blocks insecure HTTP connections

### `.npmrc` - New file for defense-in-depth

Created `.npmrc` for npm-based commands (`npm publish` in CI, `npx`, etc.):

- ✅ `ignore-scripts=true` - **Disables lifecycle scripts** (primary supply-chain attack vector)
- ✅ `allow-git=none` - Blocks git-based dependencies
- ✅ `min-release-age=3` - 3-day cooldown for new packages
- ✅ `save-exact=true` - No version ranges
- ✅ `engine-strict=true` - Enforces Node version requirements

### `package.json` - Added Node.js version constraint

- ✅ `engines: { "node": ">=20.0.0" }` - Enforces minimum Node version

## Security Benefits

1. **Prevents compromised packages**: 3-day minimum release age gives security community time to detect and report malicious package updates
2. **Blocks git dependencies**: No direct git/GitHub dependencies that bypass npm registry security scanning
3. **Disables lifecycle scripts**: Prevents `preinstall`/`install`/`postinstall` scripts from running malicious code
4. **Enforces checksums**: Package integrity validation catches tampering
5. **Immutable installs**: CI cannot silently modify lockfiles (prevents lockfile poisoning)

## Test Plan

- [x] Configuration files validated against Grafana security policy
- [ ] **Local verification required** (outside sandbox):
  ```bash
  yarn install --immutable
  yarn build
  yarn test:ci
  yarn lint
  ```
- [ ] CI workflows pass (GitHub Actions will validate on this PR)
- [ ] Verify `npm publish` workflow still works (on next release)

## Risks & Mitigations

**Risk:** The 3-day age gate (`npmMinimalAgeGate: 4320`) may block urgent dependency updates  
**Mitigation:** `@grafana/*` packages are pre-approved and bypass the gate

**Risk:** Existing transitive dependencies might use git protocols  
**Mitigation:** If `yarn install` fails, we'll need to identify and replace those dependencies (none expected based on current lockfile)

**Risk:** `approvedGitRepositories: []` is maximally restrictive  
**Mitigation:** This is intentional per Grafana policy. If a git dependency is truly needed, it must be explicitly approved and added to the list.

## References

- [Grafana Repository Security Hardening Skill](https://github.com/grafana/cursor-skills/tree/main/grafana-engineering-repository-security-hardening)
- [NPM Supply-Chain Safety Policy](workspace rule)
- Yarn Berry documentation: [Hardened Mode](https://yarnpkg.com/features/security#hardened-mode)

## Related

Addresses supply-chain security gaps. Complements existing Renovate configuration which already enforces minimum release ages for automated dependency updates.

/cc @grafana/observability-cloud-solutions

Made with [Cursor](https://cursor.com)